### PR TITLE
Redesign: editorial hero, timeline, dark-first design system, view transitions

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -3,12 +3,14 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link rel="preconnect" href="https://fonts.googleapis.com">
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+		<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 		<title>{{ title or metadata.title }}</title>
 		<meta name="description" content="{{ description or metadata.description }}">
 		<link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="{{ metadata.title }}">
 		<script src="https://analytics.ahrefs.com/analytics.js" data-key="C4amfoddIHrzNPGl4TCVzQ" async></script>
 
-		{# SEO: canonical + social sharing images #}
 		<link rel="canonical" href="{{ page.url | absoluteUrl(metadata.url) }}">
 		<meta property="og:title" content="{{ title or metadata.title }}">
 		<meta property="og:description" content="{{ description or metadata.description }}">
@@ -23,60 +25,28 @@
 			<meta name="twitter:card" content="summary">
 		{% endif %}
 
-		{# Initialize theme early to avoid flash #}
 		<script>
 			(function () {
 				try {
 					var stored = localStorage.getItem('theme');
-					var systemDark = window.matchMedia && window
-						.matchMedia('(prefers-color-scheme: dark)')
-						.matches
-							? 'dark'
-							: 'light';
-					var theme = stored || systemDark;
-					document
-						.documentElement
-						.setAttribute('data-theme', theme);
+					var theme = stored || 'dark';
+					document.documentElement.setAttribute('data-theme', theme);
 				} catch (e) {}
 			})();
 		</script>
 
-		{#- Uncomment this if you’d like folks to know that you used Eleventy to build your site!  #}
-		{#- <meta name="generator" content="{{ eleventy.generator }}"> #}
-
-		{#-
-		Plain-text bundles are provided via the `eleventy-plugin-bundle` plugin:
-		1. CSS:
-			* Add to a per-page bundle using `{% css %}{% endcss %}`
-			* Retrieve bundle content using `{% getBundle "css" %}` or `{% getBundleFileUrl "css" %}`
-		2. Or for JavaScript:
-			* Add to a per-page bundle using `{% js %}{% endjs %}`
-			* Retrieve via `{% getBundle "js" %}` or `{% getBundleFileUrl "js" %}`
-		3. Learn more: https://github.com/11ty/eleventy-plugin-bundle
-		#}
-
-		{#- Add CSS to the bundle #}
 		<style>
 			/* This is an arbitrary CSS string added to the bundle */
 		</style>
 
-		{#- Add the contents of a file to the bundle #}
 		<style>
 			{% include "css/index.css" %}
 		</style>
 
-		{#- Or you can add from node_modules #}
-		{# <style>{% include "node_modules/something.css" %}</style> #}
-
-		{#- Render the CSS bundle using inlined CSS (for the fastest site performance in production) #}
 		<style>
 			{% getBundle "css" %}
 		</style>
 
-		{#- Renders the CSS bundle using a separate file, if you can't set CSP directive style-src: 'unsafe-inline' #}
-		{#- <link rel="stylesheet" href="{% getBundleFileUrl "css" %}"> #}
-
-		{#- Add the heading-anchors web component to the JavaScript bundle #}
 		<script type="module">
 			{% include "node_modules/@zachleat/heading-anchors/heading-anchors.js" %}
 		</script>
@@ -86,22 +56,6 @@
 
 		{% include "header.njk" %}
 
-		{# <header>
-			<a href="/" class="home-link">{{ metadata.title }}</a>
-
-			Read more about `eleventy-navigation` at https://www.11ty.dev/docs/plugins/navigation/ 
-			<nav>
-				<h2 class="visually-hidden">Top level navigation menu</h2>
-				<ul class="nav">
-					{%- for entry in collections.all | eleventyNavigation %}
-						<li class="nav-item">
-							<a href="{{ entry.url }}"{% if entry.url == page.url %} aria-current="page"{% endif %}>{{ entry.title }}</a>
-						</li>
-					{%- endfor %}
-				</ul>
-			</nav>
-		</header> #}
-
 		<main id="main">
 			<heading-anchors>
 				{{ content | safe }}
@@ -109,43 +63,40 @@
 		</main>
 
 		<footer>
-			<p>
-				<em>JussMor - Copyright © 2025</a>
-			</em>
-		</p>
-	</footer>
+			<p><em>JussMor &mdash; &copy; 2025</em></p>
+		</footer>
 
-	<!-- This page `{{ page.url }}` was built on {% currentBuildDate %} -->
-	<script>
-		(function () {
-			var btn = document.getElementById('theme-toggle');
-			if (!btn) 
-				return;
-			function apply(theme) {
-				document
-					.documentElement
-					.setAttribute('data-theme', theme);
-				try {
-					localStorage.setItem('theme', theme);
-				} catch (e) {}
-				btn.setAttribute('aria-pressed', theme === 'dark');
-			}
-			btn.addEventListener('click', function () {
-				var current = document
-					.documentElement
-					.getAttribute('data-theme') || 'light';
-				apply(
-					current === 'dark'
-					? 'light'
-					: 'dark');
-			});
-			// Sync initial button state
-			var initial = document
-				.documentElement
-				.getAttribute('data-theme') || 'light';
-			btn.setAttribute('aria-pressed', initial === 'dark');
-		})();
-	</script>
-	<script type="module" src="{% getBundleFileUrl "js" %}"></script>
-</body>
+		<!-- {{ page.url }} built on {% currentBuildDate %} -->
+		<script>
+			(function () {
+				var btn = document.getElementById('theme-toggle');
+				if (!btn) return;
+				function apply(theme) {
+					document.documentElement.setAttribute('data-theme', theme);
+					try { localStorage.setItem('theme', theme); } catch (e) {}
+					btn.setAttribute('aria-pressed', theme === 'dark');
+				}
+				btn.addEventListener('click', function () {
+					var current = document.documentElement.getAttribute('data-theme') || 'dark';
+					apply(current === 'dark' ? 'light' : 'dark');
+				});
+				var initial = document.documentElement.getAttribute('data-theme') || 'dark';
+				btn.setAttribute('aria-pressed', initial === 'dark');
+			})();
+		</script>
+		<script>
+			(function () {
+				var obs = new IntersectionObserver(function (entries) {
+					entries.forEach(function (e) {
+						if (e.isIntersecting) {
+							e.target.classList.add('in-view');
+							obs.unobserve(e.target);
+						}
+					});
+				}, { threshold: 0.08 });
+				document.querySelectorAll('.reveal').forEach(function (el) { obs.observe(el); });
+			})();
+		</script>
+		<script type="module" src="{% getBundleFileUrl "js" %}"></script>
+	</body>
 </html>

--- a/content/about.njk
+++ b/content/about.njk
@@ -9,8 +9,7 @@ const description = "Full‑stack engineer: frontend, cloud, AI, education. Book
 <section class="about-hero">
 	<h1>Hi, I'm Junior Moreira.</h1>
 	<p class="lead">Product‑focused full‑stack engineer specializing in frontend architecture, cloud platforms, AI integrations, and developer education. I help teams move faster with clean systems, strong DX, and scalable foundations.</p>
-	<p class="meta">Based in Ecuador · Open to U.S. remote roles · <a href="/feed/feed.xml">RSS</a>
-	</p>
+	<p class="meta">Based in Ecuador &middot; Open to U.S. remote roles &middot; <a href="/feed/feed.xml">RSS</a></p>
 	{% if metadata.calendarUrl %}
 		<p class="about-hero-cta">
 			<a class="btn btn-primary" href="{{ metadata.calendarUrl }}" target="_blank" rel="noopener noreferrer">Book a Power Up</a>
@@ -22,59 +21,76 @@ const description = "Full‑stack engineer: frontend, cloud, AI, education. Book
 	<h2>Core Expertise</h2>
 	<ul class="pill-list">
 		<li>Frontend Platforms (React, Qwik, SvelteKit)</li>
-		<li>Design Systems & Server‑Driven UI</li>
-		<li>Cloud & Edge (AWS, Cloudflare)</li>
-		<li>AI & LLM Integration</li>
+		<li>Design Systems &amp; Server‑Driven UI</li>
+		<li>Cloud &amp; Edge (AWS, Cloudflare)</li>
+		<li>AI &amp; LLM Integration</li>
 		<li>Monorepos (Nx)</li>
-		<li>APIs & FastAPI</li>
-		<li>Performance & Observability</li>
+		<li>APIs &amp; FastAPI</li>
+		<li>Performance &amp; Observability</li>
 		<li>Developer Experience Tooling</li>
 	</ul>
 </section>
 
 <section class="experience">
 	<h2>Experience</h2>
-	<div class="xp-grid">
-		<article class="xp-card">
-			<h3>Everbetter Medicine</h3>
-			<p class="role">Senior Front-End Engineer · 2025–2026 · Remote (US)</p>
+	<div class="timeline">
+
+		<div class="timeline-item reveal" style="--reveal-delay: 0ms">
+			<div class="timeline-header">
+				<h3>Everbetter Medicine</h3>
+				<span class="timeline-period">2025&ndash;2026</span>
+			</div>
+			<p class="timeline-role">Senior Front-End Engineer &middot; Remote (US)</p>
 			<ul>
-				<li>Led frontend development for a mobile-first healthcare platform using React, TypeScript, and AWS services.</li>
-				<li>Built patient-facing dashboards and account management features with React, REST APIs, and responsive UI patterns.</li>
-				<li>Integrated third-party APIs and AI-assisted recommendation features through external API integration.</li>
-				<li>Improved performance with lazy loading, reusable hooks, and optimized rendering for mobile devices.</li>
+				<li>Led frontend for a mobile-first healthcare platform using React, TypeScript, and AWS.</li>
+				<li>Built patient dashboards and account management with React, REST APIs, and responsive UI patterns.</li>
+				<li>Integrated AI-assisted recommendations and third-party APIs via external API integration.</li>
+				<li>Improved mobile performance with lazy loading, reusable hooks, and optimized rendering.</li>
 			</ul>
-		</article>
-		<article class="xp-card">
-			<h3>Jobsity</h3>
-			<p class="role">Full Stack Developer · 2022–2024 · Remote (US)</p>
+		</div>
+
+		<div class="timeline-item reveal" style="--reveal-delay: 80ms">
+			<div class="timeline-header">
+				<h3>Jobsity</h3>
+				<span class="timeline-period">2022&ndash;2024</span>
+			</div>
+			<p class="timeline-role">Full Stack Developer &middot; Remote (US)</p>
 			<ul>
 				<li>Built and scaled e-commerce and FinTech platforms using Next.js, React, TypeScript, and Tailwind CSS.</li>
 				<li>Designed a GraphQL API gateway with Apollo, NestJS, and Redis, unifying data from multiple backends.</li>
 				<li>Built backend services for transaction monitoring using NestJS, PostgreSQL, Redis, and event-driven patterns.</li>
 				<li>Migrated legacy .NET services to Node.js/NestJS and set up Docker-based CI/CD pipelines.</li>
 			</ul>
-		</article>
-		<article class="xp-card">
-			<h3>Accenture</h3>
-			<p class="role">Back-End Engineer · 2021–2022 · Remote, Contract (AR)</p>
+		</div>
+
+		<div class="timeline-item reveal" style="--reveal-delay: 160ms">
+			<div class="timeline-header">
+				<h3>Accenture</h3>
+				<span class="timeline-period">2021&ndash;2022</span>
+			</div>
+			<p class="timeline-role">Back-End Engineer &middot; Remote, Contract (AR)</p>
 			<ul>
-				<li>Built backend services for an e-commerce SaaS platform using Python (FastAPI) for product, order, and auth flows.</li>
+				<li>Built backend services for an e-commerce SaaS using Python (FastAPI) for product, order, and auth flows.</li>
 				<li>Designed and optimized data models in PostgreSQL and MongoDB for high-traffic endpoints.</li>
 				<li>Implemented serverless components with AWS Lambda and API Gateway for scalable background jobs.</li>
 				<li>Automated build and deployment workflows with CI/CD pipelines (GitHub Actions / Jenkins).</li>
 			</ul>
-		</article>
-		<article class="xp-card">
-			<h3>Eduland Academy</h3>
-			<p class="role">Software Developer · 2017–2021 · Remote (EC)</p>
+		</div>
+
+		<div class="timeline-item reveal" style="--reveal-delay: 240ms">
+			<div class="timeline-header">
+				<h3>Eduland Academy</h3>
+				<span class="timeline-period">2017&ndash;2021</span>
+			</div>
+			<p class="timeline-role">Software Developer &middot; Remote (EC)</p>
 			<ul>
 				<li>Developed full-stack features using React and Node.js (Express) for e-commerce and SaaS applications.</li>
 				<li>Built and maintained RESTful APIs for product catalog management, user authentication, and order processing.</li>
 				<li>Designed relational data models in PostgreSQL with optimized queries for high-usage endpoints.</li>
 				<li>Set up CI/CD pipelines (GitHub Actions / Jenkins), automating testing and deployment processes.</li>
 			</ul>
-		</article>
+		</div>
+
 	</div>
 </section>
 
@@ -85,62 +101,97 @@ const description = "Full‑stack engineer: frontend, cloud, AI, education. Book
 		<article class="service-card">
 			<h3>1:1 Engineering Call</h3>
 			<p class="price">$35 <span>/ 60 min</span></p>
-			<p class="desc">Architecture review, career guidance, or debugging a tough problem. You bring context—leave with a clear path.</p>
-			<a class="btn btn-primary" href="https://buy.stripe.com/cNi28q8d364B32m1Kv43S00" rel="noopener" target="_blank">Book 1 Hour →</a>
+			<p class="desc">Architecture review, career guidance, or debugging a tough problem. You bring context&mdash;leave with a clear path.</p>
+			<a class="btn btn-primary" href="https://buy.stripe.com/cNi28q8d364B32m1Kv43S00" rel="noopener" target="_blank">Book 1 Hour &rarr;</a>
 		</article>
 		<article class="service-card">
 			<h3>Career Support Pack</h3>
-			<p class="price">2 × 50 min <span>($50)</span></p>
-			<p class="desc">Two deep sessions: positioning, portfolio/code review, roadmap & accountability. Ideal for transitions or leveling up.</p>
-			<a class="btn" href="https://buy.stripe.com/3cI5kCeBr3Wt7iC0Gr43S01" rel="noopener" target="_blank">Reserve Pack →</a>
+			<p class="price">2 &times; 50 min <span>($50)</span></p>
+			<p class="desc">Two deep sessions: positioning, portfolio/code review, roadmap &amp; accountability. Ideal for transitions or leveling up.</p>
+			<a class="btn" href="https://buy.stripe.com/3cI5kCeBr3Wt7iC0Gr43S01" rel="noopener" target="_blank">Reserve Pack &rarr;</a>
 		</article>
 		<article class="service-card alt">
 			<h3>Team Advisory (Inquiry)</h3>
 			<p class="price">Custom</p>
 			<p class="desc">Need help with monorepo strategy, DX tooling, or AI integration? I can embed short‑term to accelerate delivery.</p>
-			<a class="btn" href="mailto:contact@jussmor.com?subject=Team%20Advisory%20Inquiry">Start Conversation →</a>
+			<a class="btn" href="mailto:contact@jussmor.com?subject=Team%20Advisory%20Inquiry">Start Conversation &rarr;</a>
 		</article>
 	</div>
 </section>
 
 <section class="cta">
-	<h2>Let's Build Something</h2>
+	<h2>Let&rsquo;s Build Something</h2>
 	<p>Email <a href="mailto:contact@jussmor.com">contact@jussmor.com</a> or connect on <a href="https://www.linkedin.com/in/jussmor/" target="_blank" rel="noopener">LinkedIn</a>.</p>
 </section>
 
 {% css %}
-.about-hero { max-width: 60rem; margin: 0 auto 2.5rem; }
-.about-hero h1 { margin: 0 0 .6rem; font-size: clamp(2rem,4vw,2.8rem); }
-.about-hero .lead { font-size: 1.05rem; line-height: 1.5; color: var(--text-muted); }
-.about-hero .meta { font-size: .85rem; color: var(--text-muted); margin-top: .75rem; }
+.about-hero { max-width: 60rem; margin: 0 auto 3rem; }
+.about-hero h1 { margin: 0 0 .7rem; font-size: clamp(2rem,4vw,2.8rem); }
+.about-hero .lead { font-size: 1.05rem; line-height: 1.6; color: var(--text-muted); max-width: 60ch; }
+.about-hero .meta { font-size: .82rem; color: var(--text-muted); margin-top: .75rem; }
+.about-hero-cta { margin-top: 1.5rem; }
 
-.pill-list { list-style: none; padding:0; margin: .75rem 0 2rem; display: flex; flex-wrap: wrap; gap: .5rem; }
-.pill-list li { padding: .45rem .75rem; font-size: .8rem; border:1px solid var(--border-color); border-radius: 999px; background: var(--elevated-color); }
+.pill-list { list-style: none; padding: 0; margin: .75rem 0 2.5rem; display: flex; flex-wrap: wrap; gap: .4rem; }
+.pill-list li { padding: .4rem .75rem; font-size: .78rem; border: 1px solid var(--border-color); border-radius: 999px; background: var(--elevated-color); color: var(--text-muted); }
 
-.expertise, .experience, .services, .cta { max-width: 60rem; margin: 0 auto 3rem; }
-.experience h2, .expertise h2, .services h2, .cta h2 { font-size: 1.4rem; margin-bottom: .75rem; }
+.expertise, .experience, .services, .cta { max-width: 60rem; margin: 0 auto 3.5rem; }
+.expertise h2, .experience h2, .services h2, .cta h2 { font-size: 1.35rem; margin-bottom: 1.25rem; font-weight: 600; }
 
-.xp-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit,minmax(260px,1fr)); }
-.xp-card { border:1px solid var(--border-color); border-radius: var(--radius); background: var(--surface-color); padding: 1rem 1.1rem .9rem; box-shadow: var(--shadow-sm); }
-.xp-card h3 { margin: 0 0 .35rem; font-size: 1.05rem; }
-.xp-card .role { margin: 0 0 .5rem; font-size: .75rem; font-weight: 600; letter-spacing: .5px; color: var(--text-muted); text-transform: uppercase; }
-.xp-card ul { margin: 0; padding-left: 1.1rem; font-size: .85rem; line-height: 1.35; }
-.xp-card li { margin-bottom: .4rem; }
+/* Timeline */
+.timeline {
+	position: relative;
+	padding-left: 1.75rem;
+}
+.timeline::before {
+	content: '';
+	position: absolute;
+	left: 0; top: .5rem; bottom: .5rem;
+	width: 1px;
+	background: var(--border-color);
+}
+.timeline-item {
+	position: relative;
+	padding-bottom: 2.75rem;
+}
+.timeline-item:last-child { padding-bottom: 0; }
+.timeline-item::before {
+	content: '';
+	position: absolute;
+	left: -2.15rem;
+	top: .5rem;
+	width: 7px; height: 7px;
+	border-radius: 50%;
+	background: var(--accent);
+	box-shadow: 0 0 10px var(--accent-dim);
+}
+.timeline-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	gap: 1rem;
+	margin-bottom: .2rem;
+}
+.timeline-header h3 { margin: 0; font-size: 1.05rem; font-weight: 600; }
+.timeline-period { font-size: .72rem; color: var(--text-muted); white-space: nowrap; letter-spacing: .06em; }
+.timeline-role { margin: 0 0 .65rem; font-size: .72rem; font-weight: 500; letter-spacing: .08em; color: var(--text-muted); text-transform: uppercase; }
+.timeline-item ul { margin: 0; padding-left: 1rem; font-size: .875rem; line-height: 1.55; color: var(--text-muted); }
+.timeline-item li { margin-bottom: .35rem; }
 
+/* Services */
 .service-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit,minmax(240px,1fr)); align-items: stretch; }
-.service-card { position: relative; display:flex; flex-direction:column; border:1px solid var(--border-color); border-radius: var(--radius); background: var(--surface-color); padding: 1.15rem 1.15rem 1.2rem; box-shadow: var(--shadow-sm); transition: transform .12s ease, box-shadow .2s ease; }
+.service-card { position: relative; display: flex; flex-direction: column; border: 1px solid var(--border-color); border-radius: var(--radius); background: var(--surface-color); padding: 1.15rem 1.15rem 1.2rem; box-shadow: var(--shadow-sm); transition: transform .12s ease, box-shadow .2s ease; }
 .service-card:hover { transform: translateY(-2px); box-shadow: var(--shadow); }
-.service-card.alt { background: linear-gradient(140deg, color-mix(in oklab, var(--surface-color) 96%, transparent), color-mix(in oklab, var(--elevated-color) 92%, transparent)); }
+.service-card.alt { background: var(--elevated-color); }
 .service-card h3 { margin: 0 0 .4rem; font-size: 1rem; }
 .service-card .price { margin: 0 0 .4rem; font-size: .9rem; font-weight: 600; color: var(--text-color); }
 .service-card .price span { font-weight: normal; color: var(--text-muted); }
-.service-card .desc { flex-grow:1; font-size: .8rem; line-height: 1.4; color: var(--text-muted); margin: 0 0 .75rem; }
+.service-card .desc { flex-grow: 1; font-size: .82rem; line-height: 1.5; color: var(--text-muted); margin: 0 0 .75rem; }
 .service-card .btn { width: 100%; justify-content: center; font-size: .85rem; }
-.note { margin-top: 1rem; font-size: .7rem; color: var(--text-muted); }
 
-.cta { text-align: center; padding: 2.5rem 1rem 3rem; border:1px solid var(--border-color); border-radius: var(--radius-lg); background: var(--surface-color); box-shadow: var(--shadow); }
-.cta h2 { margin:0 0 .75rem; font-size: 1.6rem; }
-.cta p { margin:0; font-size: .95rem; }
+/* CTA */
+.cta { text-align: center; padding: 2.5rem 1rem 3rem; border: 1px solid var(--border-color); border-radius: var(--radius-lg); background: var(--surface-color); box-shadow: var(--shadow); }
+.cta h2 { margin: 0 0 .75rem; font-size: 1.6rem; }
+.cta p { margin: 0; font-size: .95rem; }
 
-@media (min-width: 800px) { .service-card h3 { font-size: 1.05rem; } }
+@media (min-width: 640px) { .timeline-header h3 { font-size: 1.1rem; } }
 {% endcss %}

--- a/content/index.njk
+++ b/content/index.njk
@@ -3,42 +3,30 @@ const eleventyNavigation = {
 	key: "Home",
 	order: 1
 };
-
 const numberOfLatestPostsToShow = 12;
 ---
 {% set postsCount = collections.posts | length %}
 {% set latestPostsCount = postsCount | min(numberOfLatestPostsToShow) %}
 
-<section class="hero">
-	<div class="hero-inner">
-		<h1 class="hero-title">Insights, code, and experiments</h1>
-		<p class="hero-subtitle">Writing about frontend, cloud, and crypto—clean, fast, and minimal.</p>
-	</div>
-	<div class="hero-cta">
-		<a class="btn btn-primary" href="/insights/blog/">Browse archive</a>
-		<a class="btn" href="/about/">About me</a>
+<section class="hero-main">
+	<p class="hero-eyebrow">Senior Full-Stack &middot; AI &middot; Cloud</p>
+	<h1 class="hero-name">Junior<br>Moreira.</h1>
+	<p class="hero-desc">9+ years shipping scalable systems across FinTech and E-commerce. React, NestJS, Python &mdash; built for production.</p>
+	<div class="hero-actions">
+		<a class="btn btn-primary" href="/about/">Work with me &rarr;</a>
+		<a class="btn" href="/insights/blog/">Read insights</a>
 		{% if metadata.calendarUrl %}
-			<a class="btn btn-primary" href="{{ metadata.calendarUrl }}" target="_blank" rel="noopener noreferrer">Book a Power Up</a>
+			<a class="btn" href="{{ metadata.calendarUrl }}" target="_blank" rel="noopener noreferrer">Book a call</a>
 		{% endif %}
 	</div>
-	<div class="hero-metrics">
-		<span>{{ postsCount }} posts</span>
-		<span>•</span>
-		<span>Updated {{ collections.posts[0].date | readableDate('LLLL yyyy') }}</span>
-	</div>
-	<div class="hero-gradient" aria-hidden="true"></div>
-	<div class="hero-grid" aria-hidden="true"></div>
-	<div class="hero-noise" aria-hidden="true"></div>
-	<div class="hero-glow" aria-hidden="true"></div>
 </section>
 
-<section class="cards">
-	<h2 class="section-title">Latest {{ latestPostsCount }} post{% if latestPostsCount != 1 %}s{% endif %}
-	</h2>
+<section class="posts-section">
+	<h2 class="section-label">Latest {{ latestPostsCount }} post{% if latestPostsCount != 1 %}s{% endif %}</h2>
 	<div class="card-grid">
 		{% set posts = collections.posts | head(-1 * numberOfLatestPostsToShow) | reverse %}
 		{% for post in posts %}
-			<article class="card">
+			<article class="card reveal" style="--reveal-delay: {{ loop.index0 * 40 }}ms">
 				<a class="card-link" href="{{ post.url }}" aria-label="Read {{ post.data.title }}"></a>
 				<div class="card-body">
 					<h3 class="card-title">{{ post.data.title }}</h3>
@@ -46,12 +34,10 @@ const numberOfLatestPostsToShow = 12;
 					<div class="card-meta">
 						<time datetime="{{ post.date | htmlDateString }}">{{ post.date | readableDate('dd LLL yyyy') }}</time>
 						{% if post.data.tags %}
-							<span class="card-dot" aria-hidden="true">•</span>
+							<span class="card-dot" aria-hidden="true">&bull;</span>
 							<ul class="card-tags">
 								{% for tag in post.data.tags | filterTagList %}
-									<li>
-										<a href="/tags/{{ tag | slugify }}/" class="post-tag">{{ tag }}</a>
-									</li>
+									<li><a href="/tags/{{ tag | slugify }}/" class="post-tag">{{ tag }}</a></li>
 								{% endfor %}
 							</ul>
 						{% endif %}
@@ -60,11 +46,8 @@ const numberOfLatestPostsToShow = 12;
 			</article>
 		{% endfor %}
 	</div>
-
 	{% set morePosts = postsCount - numberOfLatestPostsToShow %}
 	{% if morePosts > 0 %}
-		<p class="more-link">
-			<a href="/insights/blog/">View {{ morePosts }} more post{% if morePosts != 1 %}s{% endif %} in the archive →</a>
-		</p>
+		<p class="more-link"><a href="/insights/blog/">View {{ morePosts }} more post{% if morePosts != 1 %}s{% endif %} &rarr;</a></p>
 	{% endif %}
 </section>

--- a/css/index.css
+++ b/css/index.css
@@ -1,90 +1,113 @@
-/* Defaults */
-
+/* ── Tokens ───────────────────────────────────────────────── */
 :root {
-	--font-family: -apple-system, system-ui, sans-serif;
-	--font-family-monospace: Consolas, Menlo, Monaco, Andale Mono WT, Andale Mono, Lucida Console, Lucida Sans Typewriter, DejaVu Sans Mono, Bitstream Vera Sans Mono, Liberation Mono, Nimbus Mono L, Courier New, Courier, monospace;
-}
+	--font-family: 'Outfit', -apple-system, system-ui, sans-serif;
+	--font-family-monospace: Consolas, Menlo, Monaco, 'Andale Mono WT', monospace;
 
-/* Theme colors */
-:root {
-	/* base neutrals */
-	--color-gray-5: #f7f7f8;
-	--color-gray-10: #eeeef0;
-	--color-gray-20: #e0e0e0;
-	--color-gray-50: #C0C0C0;
-	--color-gray-70: #6b7280;
-	--color-gray-90: #333;
+	--accent:     #00e5a0;
+	--accent-dim: rgba(0,229,160,0.14);
 
-	/* light theme */
-	--background-color: #ffffff;
-	--surface-color: #ffffff;
-	--elevated-color: #fafafa;
-	--border-color: rgba(0,0,0,0.08);
-
-	--text-color: #1f2937;
-	--text-muted: #6b7280;
-	--text-color-link: #0b5fff;
-	--text-color-link-active: #3b82f6;
-	--text-color-link-visited: #6d28d9;
-
-	--shadow-sm: 0 1px 2px rgba(0,0,0,0.06);
-	--shadow: 0 8px 30px rgba(0,0,0,0.08);
-
-	--radius: 14px;
-	--radius-sm: 10px;
-	--radius-lg: 20px;
-
-	--syntax-tab-size: 2;
-}
-
-/* dark theme via attribute (overrides) */
-[data-theme="dark"] {
-	--color-gray-5: #0b0c10;
+	--color-gray-5:  #0b0c0e;
 	--color-gray-10: #111216;
 	--color-gray-20: #2a2b31;
 	--color-gray-50: #747887;
 	--color-gray-70: #9aa1af;
 	--color-gray-90: #dad8d8;
 
-	--background-color: #0b0c10;
-	--surface-color: #0f1117;
-	--elevated-color: #11131a;
-	--border-color: rgba(255,255,255,0.08);
-
-	--text-color: #e5e7eb;
-	--text-muted: #9aa1af;
-	--text-color-link: #8ab4ff;
-	--text-color-link-active: #a0b9ff;
-	--text-color-link-visited: #c3b5ff;
-
-	--shadow-sm: 0 1px 2px rgba(0,0,0,0.5);
-	--shadow: 0 12px 50px rgba(0,0,0,0.6);
+	/* dark (default) */
+	--background-color: #080808;
+	--surface-color:    #111111;
+	--elevated-color:   #1a1a1a;
+	--border-color:     rgba(255,255,255,0.08);
+	--text-color:       #f0f0f0;
+	--text-muted:       #888888;
+	--text-color-link:         #f0f0f0;
+	--text-color-link-active:  var(--accent);
+	--text-color-link-visited: #aaaaaa;
+	--shadow-sm: 0 1px 3px rgba(0,0,0,0.5);
+	--shadow:    0 12px 50px rgba(0,0,0,0.6);
+	--radius:    12px;
+	--radius-sm: 8px;
+	--radius-lg: 18px;
+	--syntax-tab-size: 2;
 }
 
-
-/* Global stylesheet */
-* {
-	box-sizing: border-box;
+[data-theme="light"] {
+	--color-gray-5:  #f7f7f8;
+	--color-gray-10: #eeeef0;
+	--color-gray-20: #e0e0e0;
+	--color-gray-50: #c0c0c0;
+	--color-gray-70: #6b7280;
+	--color-gray-90: #333333;
+	--background-color: #ffffff;
+	--surface-color:    #fafafa;
+	--elevated-color:   #f4f4f5;
+	--border-color:     rgba(0,0,0,0.08);
+	--text-color:       #111111;
+	--text-muted:       #666666;
+	--text-color-link:         #111111;
+	--text-color-link-active:  #059669;
+	--text-color-link-visited: #444444;
+	--shadow-sm: 0 1px 2px rgba(0,0,0,0.06);
+	--shadow:    0 8px 30px rgba(0,0,0,0.08);
 }
 
-@view-transition {
-	navigation: auto;
-}
+/* ── View Transitions ─────────────────────────────────────── */
+@view-transition { navigation: auto; }
 
-html,
-body {
+header { view-transition-name: site-nav; }
+
+::view-transition-old(root) { animation: 180ms ease-in  vt-out; }
+::view-transition-new(root) { animation: 320ms ease-out vt-in;  }
+
+@keyframes vt-out { to   { opacity: 0; transform: translateY(-10px); } }
+@keyframes vt-in  { from { opacity: 0; transform: translateY(14px);  } }
+
+/* ── Reset ────────────────────────────────────────────────── */
+* { box-sizing: border-box; }
+
+html, body {
 	padding: 0;
 	margin: 0 auto;
 	font-family: var(--font-family);
 	color: var(--text-color);
 	background-color: var(--background-color);
 }
-html {
-	overflow-y: scroll;
+html { overflow-y: scroll; }
+
+img { max-width: 100%; }
+img[width][height] { height: auto; }
+img[src$=".svg"] { width: 100%; height: auto; max-width: none; }
+video, iframe { width: 100%; height: auto; }
+iframe { aspect-ratio: 16/9; }
+
+p:last-child { margin-bottom: 0; }
+p  { line-height: 1.65; }
+li { line-height: 1.65; }
+
+a[href]         { color: var(--text-color-link); }
+a[href]:visited { color: var(--text-color-link-visited); }
+a[href]:hover,
+a[href]:active  { color: var(--text-color-link-active); }
+
+main, footer {
+	padding: 1rem;
+	max-width: 61.25em;
+	margin: auto;
 }
 
+table { margin: 1em 0; }
+table td, table th { padding-right: 1em; }
 
-/* https://www.a11yproject.com/posts/how-to-hide-content/ */
+/* ── Reveal ───────────────────────────────────────────────── */
+.reveal {
+	opacity: 0;
+	transform: translateY(24px);
+	transition: opacity 0.55s ease, transform 0.55s ease;
+	transition-delay: var(--reveal-delay, 0ms);
+}
+.reveal.in-view { opacity: 1; transform: translateY(0); }
+
+/* ── Accessibility ────────────────────────────────────────── */
 .visually-hidden:not(:focus):not(:active) {
 	clip: rect(0 0 0 0);
 	clip-path: inset(50%);
@@ -95,86 +118,6 @@ html {
 	width: 1px;
 }
 
-/* Fluid images via https://www.zachleat.com/web/fluid-images/ */
-img{
-  max-width: 100%;
-}
-img[width][height] {
-  height: auto;
-}
-img[src$=".svg"] {
-  width: 100%;
-  height: auto;
-  max-width: none;
-}
-video,
-iframe {
-	width: 100%;
-	height: auto;
-}
-iframe {
-	aspect-ratio: 16/9;
-}
-
-p:last-child {
-	margin-bottom: 0;
-}
-p {
-	line-height: 1.5;
-}
-
-li {
-	line-height: 1.5;
-}
-
-a[href] {
-	color: var(--text-color-link);
-}
-a[href]:visited {
-	color: var(--text-color-link-visited);
-}
-a[href]:hover,
-a[href]:active {
-	color: var(--text-color-link-active);
-}
-
-main,
-footer {
-	padding: 1rem;
-	max-width: 61.25em;
-	margin-top: 0;
-	margin: auto;
-}
-
-/* buttons */
-.btn {
-	display: inline-flex;
-	align-items: center;
-	gap: .5rem;
-	padding: .6rem 1rem;
-	border-radius: var(--radius-sm);
-	border: 1px solid var(--border-color);
-	background: var(--surface-color);
-	color: var(--text-color);
-	text-decoration: none;
-	box-shadow: var(--shadow-sm);
-	transition: transform .08s ease, background .2s ease, border-color .2s ease;
-}
-.btn:hover { transform: translateY(-1px); }
-.btn:active { transform: translateY(0); }
-.btn-primary {
-	background: linear-gradient(180deg, rgba(59,130,246,.9), rgba(37,99,235,.9));
-	border: 1px solid rgba(59,130,246,.5);
-	color: white !important;
-}
-[data-theme="dark"] .btn-primary {
-	background: linear-gradient(180deg, rgba(59,130,246,.7), rgba(29,78,216,.7));
-	border: 1px solid rgba(96,165,250,.35);
-}
-
-
-
-
 #skip-link {
 	text-decoration: none;
 	background: var(--background-color);
@@ -183,144 +126,97 @@ footer {
 	border: 1px solid var(--color-gray-90);
 	border-radius: 2px;
 }
-
-/* Prevent visually-hidden skip link fom pushing content around when focused */
 #skip-link.visually-hidden:focus {
-	position: absolute;
-	top: 1rem;
-	left: 1rem;
-	/* Ensure it is positioned on top of everything else when it is shown */
-	z-index: 999;
+	position: absolute; top: 1rem; left: 1rem; z-index: 999;
 }
 
-.links-nextprev {
-	display: flex;
-	justify-content: space-between;
-	gap: .5em 1em;
-	list-style: "";
-	border-top: 1px dashed var(--color-gray-20);
-	padding: 1em 0;
-}
-.links-nextprev > * {
-	flex-grow: 1;
-}
-.links-nextprev-next {
-	text-align: right;
-}
-
-table {
-	margin: 1em 0;
-}
-table td,
-table th {
-	padding-right: 1em;
-}
-
-pre,
-code {
-	font-family: var(--font-family-monospace);
-}
-pre:not([class*="language-"]) {
-	margin: .5em 0;
-	line-height: 1.375; /* 22px /16 */
-	-moz-tab-size: var(--syntax-tab-size);
-	-o-tab-size: var(--syntax-tab-size);
-	tab-size: var(--syntax-tab-size);
-	-webkit-hyphens: none;
-	-ms-hyphens: none;
-	hyphens: none;
-	direction: ltr;
-	text-align: left;
-	white-space: pre;
-	word-spacing: normal;
-	word-break: normal;
-	overflow-x: auto;
-}
-code {
-	word-break: break-all;
-}
-
-/* Header */
-header {
-	display: flex;
-	border-bottom: 1px dashed var(--color-gray-20);
-	gap: 1em;
-	flex-wrap: wrap;
-	justify-content: center;
+/* ── Buttons ──────────────────────────────────────────────── */
+.btn {
+	display: inline-flex;
 	align-items: center;
-	padding: 1em;
-}
-.home-link {
-	flex-grow: 1;
-	font-size: 1em; /* 16px /16 */
-	font-weight: 700;
-}
-.home-link:link:not(:hover) {
+	gap: .5rem;
+	padding: .65rem 1.15rem;
+	border-radius: var(--radius-sm);
+	border: 1px solid var(--border-color);
+	background: var(--surface-color);
+	color: var(--text-color);
 	text-decoration: none;
+	font-family: var(--font-family);
+	font-size: .875rem;
+	font-weight: 500;
+	transition: transform .1s ease, box-shadow .2s ease, border-color .2s ease;
+}
+.btn:hover { transform: translateY(-2px); box-shadow: var(--shadow); color: var(--text-color); }
+.btn:active { transform: translateY(0); }
+
+.btn-primary {
+	background: var(--accent);
+	border-color: var(--accent);
+	color: #000 !important;
+	font-weight: 600;
+}
+.btn-primary:hover {
+	opacity: .92;
+	box-shadow: 0 0 28px var(--accent-dim), var(--shadow);
 }
 
-/* Nav */
-
+/* ── Header / Nav ─────────────────────────────────────────── */
 header {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: .75rem 1.25rem;
 	position: sticky;
 	top: 0;
-	padding: 10px 20px;
 	z-index: 999;
-	backdrop-filter: blur(10px) saturate(160%);
-	-webkit-backdrop-filter: blur(10px) saturate(160%);
+	backdrop-filter: blur(14px) saturate(160%);
+	-webkit-backdrop-filter: blur(14px) saturate(160%);
 	border-bottom: 1px solid var(--border-color);
-	background: color-mix(in oklab, var(--background-color) 70%, transparent);
+	background: color-mix(in oklab, var(--background-color) 75%, transparent);
 }
 
 .navbar {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	flex-wrap: wrap;
-	position: relative;
 	width: 100%;
 	max-width: 1024px;
 }
 
-.logo { font-size: 1.5rem; font-weight: bold; }
+.logo { font-size: 1.35rem; font-weight: 700; letter-spacing: -0.02em; }
 .site-title { text-decoration: none; color: var(--text-color); }
+.home-link { flex-grow: 1; font-size: 1em; font-weight: 700; }
+.home-link:link:not(:hover) { text-decoration: none; }
 
-nav {
-	display: flex;
-	gap: 20px;
-}
-
+nav { display: flex; gap: 2px; align-items: center; }
 nav a {
-	color: var(--text-color);
+	color: var(--text-muted);
 	text-decoration: none;
-	transition: all 0.2s ease;
-	padding: 8px 12px;
-	border-radius: 10px;
+	transition: color .15s ease, background .15s ease;
+	padding: 6px 11px;
+	border-radius: 7px;
+	font-size: .875rem;
 }
-nav a:hover {
-	background: var(--elevated-color);
-	box-shadow: var(--shadow-sm);
-}
-nav .ext-link { color: var(--text-color-link); }
+nav a:hover { color: var(--text-color); background: var(--elevated-color); }
+nav a[aria-current="page"] { color: var(--text-color); }
+nav .ext-link { color: var(--accent) !important; }
 
 .theme-toggle {
-	margin-left: .25rem;
-	padding: 8px 12px;
+	margin-left: .4rem;
+	padding: 6px 11px;
 	border-radius: 999px;
 	border: 1px solid var(--border-color);
-	background: var(--surface-color);
+	background: transparent;
 	color: var(--text-color);
 	cursor: pointer;
-	box-shadow: var(--shadow-sm);
+	font-size: .875rem;
 }
-.theme-toggle .theme-icon { display: none; }
-[data-theme="light"] .theme-toggle .theme-icon-sun { display: inline; }
-[data-theme="dark"] .theme-toggle .theme-icon-moon { display: inline; }
+.theme-toggle .theme-icon        { display: none; }
+.theme-toggle .theme-icon-moon   { display: inline; }
+[data-theme="light"] .theme-toggle .theme-icon-sun  { display: inline; }
+[data-theme="light"] .theme-toggle .theme-icon-moon { display: none; }
 
-.menu-toggle {
-	display: none;
-}
-
+.menu-toggle { display: none; }
 .hamburger {
 	display: none;
 	cursor: pointer;
@@ -328,78 +224,168 @@ nav .ext-link { color: var(--text-color-link); }
 	gap: 5px;
 	z-index: 1001;
 }
-
 .hamburger span {
-	height: 3px;
-	width: 25px;
+	height: 2px; width: 22px;
 	background: var(--text-color);
 	display: block;
 	transition: all 0.3s ease;
 }
 
 @media (max-width: 768px) {
-	.navbar {
-		flex-wrap: nowrap;
-	}
-
-	.logo {
-		flex: 1;
-	}
-
-	.hamburger {
-		display: flex;
-	}
-
+	.navbar { flex-wrap: nowrap; }
+	.logo { flex: 1; }
+	.hamburger { display: flex; }
 	nav {
 		display: flex;
 		flex-direction: column;
-		background-color: var(--surface-color);
+		background: var(--background-color);
 		position: fixed;
-		top: 47px;
-		left: 0;
-		width: 100vw;
-		height: 100vh;
+		top: 50px; left: 0;
+		width: 100vw; height: 100vh;
 		z-index: 1000;
-		padding: 20px;
-		backdrop-filter: blur(100px) saturate(180%);
-		-webkit-backdrop-filter: blur(100px) saturate(180%);
+		padding: 2rem 1.5rem;
 		border-top: 1px solid var(--border-color);
-		border-bottom: 1px solid var(--border-color);
-		box-shadow: var(--shadow);
 		transform: scaleY(0);
 		transform-origin: top;
-		transition: transform 0.4s ease-in-out, opacity 0.3s ease-in-out;
+		transition: transform 0.35s ease, opacity 0.3s ease;
 		opacity: 0;
 		pointer-events: none;
 	}
-
-	.menu-toggle:checked~nav {
-		transform: scaleY(1);
-		opacity: 1;
-		pointer-events: auto;
-	}
-
+	.menu-toggle:checked ~ nav { transform: scaleY(1); opacity: 1; pointer-events: auto; }
 	nav a {
-		padding: 10px 15px;
+		padding: 14px 0;
 		font-size: 1.1rem;
 		border-bottom: 1px solid var(--border-color);
-		border-radius: 0px;
-	}
-
-	nav a:hover {
-		background: var(--elevated-color);
-		box-shadow: var(--shadow-sm);
+		border-radius: 0;
+		color: var(--text-color);
 	}
 }
 
+/* ── Editorial Hero ───────────────────────────────────────── */
+.hero-main {
+	padding: 7rem 1rem 5rem;
+	max-width: 61.25em;
+	margin: 0 auto;
+	animation: heroIn 0.65s ease forwards;
+}
 
+@keyframes heroIn {
+	from { opacity: 0; transform: translateY(20px); }
+	to   { opacity: 1; transform: translateY(0); }
+}
 
-/* Posts list */
+.hero-eyebrow {
+	font-size: .7rem;
+	letter-spacing: .18em;
+	text-transform: uppercase;
+	color: var(--accent);
+	font-weight: 500;
+	margin: 0 0 1.5rem;
+}
+
+.hero-name {
+	font-size: clamp(3.8rem, 11vw, 9rem);
+	font-weight: 700;
+	line-height: 0.92;
+	letter-spacing: -0.03em;
+	margin: 0 0 2.5rem;
+	color: var(--text-color);
+}
+
+.hero-desc {
+	font-size: clamp(.9rem, 1.8vw, 1.05rem);
+	color: var(--text-muted);
+	line-height: 1.7;
+	margin: 0 0 2.5rem;
+	max-width: 44ch;
+}
+
+.hero-actions { display: flex; gap: .75rem; flex-wrap: wrap; }
+
+/* ── Posts section ────────────────────────────────────────── */
+.posts-section {
+	max-width: 61.25em;
+	margin: 0 auto 5rem;
+	padding: 0 1rem;
+}
+
+.section-label,
+.section-title {
+	font-size: .68rem;
+	letter-spacing: .18em;
+	text-transform: uppercase;
+	color: var(--text-muted);
+	font-weight: 500;
+	margin: 0 0 1.25rem;
+}
+
+/* ── Card grid ────────────────────────────────────────────── */
+.card-grid {
+	display: grid;
+	grid-template-columns: repeat(1, minmax(0, 1fr));
+	gap: .75rem;
+}
+@media (min-width: 640px) { .card-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (min-width: 960px) { .card-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+
+.card {
+	position: relative;
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	background: var(--surface-color);
+	transition: transform .12s ease, box-shadow .2s ease, border-color .2s ease;
+	overflow: hidden;
+}
+.card:hover {
+	transform: translateY(-3px);
+	box-shadow: var(--shadow);
+	border-color: rgba(255,255,255,0.13);
+}
+[data-theme="light"] .card:hover { border-color: rgba(0,0,0,0.13); }
+.card-link { position: absolute; inset: 0; }
+.card-body { padding: 1.1rem; }
+.card-title   { margin: 0 0 .4rem; font-size: 1rem; line-height: 1.3; font-weight: 600; }
+.card-excerpt { margin: 0 0 .75rem; color: var(--text-muted); font-size: .875rem; line-height: 1.5; }
+.card-meta {
+	color: var(--text-muted);
+	font-size: .78rem;
+	display: flex;
+	align-items: center;
+	gap: .4rem;
+	flex-wrap: wrap;
+}
+.card-dot { opacity: .4; }
+.card-tags { list-style: none; padding: 0; margin: 0; display: inline-flex; gap: .3rem; }
+.card-tags a {
+	font-size: .75rem;
+	padding: .15rem .45rem;
+	border: 1px solid var(--border-color);
+	border-radius: 999px;
+	text-decoration: none;
+	color: var(--text-muted);
+	background: var(--elevated-color);
+}
+.more-link { margin: 1.5rem 0 0; font-size: .875rem; }
+.more-link a { color: var(--text-muted); text-decoration: none; }
+.more-link a:hover { color: var(--accent); }
+
+/* ── Post navigation ──────────────────────────────────────── */
+.links-nextprev {
+	display: flex;
+	justify-content: space-between;
+	gap: .5em 1em;
+	list-style: none;
+	padding: 1em 0 0;
+	border-top: 1px solid var(--border-color);
+}
+.links-nextprev > * { flex-grow: 1; }
+.links-nextprev-next { text-align: right; }
+
+/* ── Postlist (archive) ───────────────────────────────────── */
 .postlist {
 	counter-reset: start-from var(--postlist-index);
 	list-style: none;
-	padding: 0;
-	padding-left: 1.5rem;
+	padding: 0 0 0 1.5rem;
 }
 .postlist-item {
 	display: flex;
@@ -417,85 +403,19 @@ nav .ext-link { color: var(--text-color-link); }
 	margin-left: -1.5rem;
 }
 .postlist-date,
-.postlist-item:before {
-	font-size: 0.8125em; /* 13px /16 */
-	color: var(--color-gray-90);
-}
-.postlist-date {
-	word-spacing: -0.5px;
-}
+.postlist-item:before { font-size: 0.8125em; color: var(--text-muted); }
+.postlist-date { word-spacing: -0.5px; }
 .postlist-link {
-	font-size: 1.1875em; /* 19px /16 */
+	font-size: 1.1875em;
 	font-weight: 700;
 	flex-basis: calc(100% - 1.5rem);
 	padding-left: .25em;
 	padding-right: .5em;
 	text-underline-position: from-font;
-	text-underline-offset: 0;
 	text-decoration-thickness: 1px;
 }
-.postlist-item-active .postlist-link {
-	font-weight: bold;
-}
 
-/* Hero */
-.hero {
-	position: relative;
-	border: 1px solid var(--border-color);
-	border-radius: var(--radius-lg);
-	padding: 2rem 1rem;
-	margin: 1rem auto 2rem;
-	max-width: 61.25em;
-	background: linear-gradient(
-		180deg,
-		color-mix(in oklab, var(--surface-color) 96%, transparent),
-		color-mix(in oklab, var(--surface-color) 92%, transparent)
-	);
-	box-shadow: var(--shadow);
-}
-.hero-title { font-size: clamp(1.6rem, 3vw, 2.2rem); margin: 0 0 .4rem; }
-.hero-subtitle { color: var(--text-muted); margin: 0 0 1rem; }
-.hero-cta { display: flex; gap: .6rem; flex-wrap: wrap; }
-.hero-metrics { color: var(--text-muted); margin-top: 1rem; font-size: .95rem; }
-.hero-gradient, .hero-grid, .hero-noise, .hero-glow { position: absolute; inset: 0; border-radius: inherit; pointer-events: none; }
-.hero-gradient { background: radial-gradient(60% 60% at 10% 0%, rgba(59,130,246,.25), transparent 60%), radial-gradient(50% 60% at 90% 10%, rgba(236,72,153,.2), transparent 60%); filter: blur(8px); }
-[data-theme="dark"] .hero-gradient { background: radial-gradient(60% 60% at 10% 0%, rgba(59,130,246,.15), transparent 60%), radial-gradient(50% 60% at 90% 10%, rgba(236,72,153,.12), transparent 60%); }
-.hero-grid { background-image: linear-gradient(var(--border-color) 1px, transparent 1px), linear-gradient(90deg, var(--border-color) 1px, transparent 1px); background-size: 24px 24px; opacity: .25; }
-.hero-noise { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.035'/%3E%3C/svg%3E"); border-radius: inherit; }
-.hero-glow { box-shadow: 0 0 120px rgba(59,130,246,.18); border-radius: inherit; }
-
-/* Card grid */
-.cards { max-width: 61.25em; margin: 0 auto 3rem; padding: 0 1rem; }
-.section-title { font-size: 1.25rem; margin: 0 0 1rem; }
-.card-grid {
-	display: grid;
-	grid-template-columns: repeat(1, minmax(0,1fr));
-	gap: 1rem;
-}
-@media (min-width: 640px) { .card-grid { grid-template-columns: repeat(2, minmax(0,1fr)); } }
-@media (min-width: 960px) { .card-grid { grid-template-columns: repeat(3, minmax(0,1fr)); } }
-
-.card {
-	position: relative;
-	border: 1px solid var(--border-color);
-	border-radius: var(--radius);
-	background: var(--surface-color);
-	box-shadow: var(--shadow-sm);
-	transition: transform .12s ease, box-shadow .2s ease, border-color .2s ease;
-	overflow: hidden;
-}
-.card:hover { transform: translateY(-2px); box-shadow: var(--shadow); }
-.card-link { position: absolute; inset: 0; }
-.card-body { padding: 1rem; }
-.card-title { margin: 0 0 .5rem; font-size: 1.05rem; line-height: 1.3; }
-.card-excerpt { margin: 0 0 .75rem; color: var(--text-muted); font-size: .95rem; }
-.card-meta { color: var(--text-muted); display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; }
-.card-tags { list-style: none; padding: 0; margin: 0; display: inline-flex; gap: .35rem; }
-.card-tags a { font-style: normal; font-size: .85rem; padding: .2rem .5rem; border: 1px solid var(--border-color); border-radius: 999px; text-decoration: none; color: var(--text-color); background: var(--elevated-color); }
-.more-link { margin: 1.25rem 0 0; }
-
-
-/* Tags */
+/* ── Tags ─────────────────────────────────────────────────── */
 .post-tag {
 	display: inline-flex;
 	align-items: center;
@@ -503,20 +423,37 @@ nav .ext-link { color: var(--text-color-link); }
 	text-transform: capitalize;
 	font-style: italic;
 }
-.postlist-item > .post-tag {
-	align-self: center;
-}
-
-/* Tags list */
 .post-metadata {
 	display: inline-flex;
 	flex-wrap: wrap;
 	gap: .5em;
 	list-style: none;
-	padding: 0;
-	margin: 0;
+	padding: 0; margin: 0;
 }
-.post-metadata time {
-	margin-right: 1em;
-}
+.post-metadata time { margin-right: 1em; }
 
+/* ── Code ─────────────────────────────────────────────────── */
+pre, code { font-family: var(--font-family-monospace); }
+pre:not([class*="language-"]) {
+	margin: .5em 0;
+	line-height: 1.375;
+	-moz-tab-size: var(--syntax-tab-size);
+	tab-size: var(--syntax-tab-size);
+	hyphens: none;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	overflow-x: auto;
+}
+code { word-break: break-all; }
+
+/* ── Footer ───────────────────────────────────────────────── */
+footer {
+	border-top: 1px solid var(--border-color);
+	margin-top: 3rem;
+	padding-top: 1.5rem;
+	font-size: .82rem;
+	color: var(--text-muted);
+}


### PR DESCRIPTION
## Summary\n\n- **Homepage** — replaced blog-index hero with editorial full-name display (`Junior / Moreira.`), eyebrow label in accent green, muted desc, CTA buttons. Blog grid kept below with stagger reveal.\n- **Experience** — vertical timeline with accent-colored glowing dots, replacing the flat card grid. Four companies with inline reveal delays (0 / 80 / 160 / 240ms).\n- **Design system** — `Outfit` font, dark-first (root = dark, `[data-theme=\"light\"]` override), accent `#00e5a0` (electric mint) used on eyebrow, dots, links, primary buttons.\n- **View transitions** — `@view-transition { navigation: auto }` with custom slide-up keyframes (`vt-in` / `vt-out`). Header pinned with `view-transition-name: site-nav` so it stays stable across pages.\n- **Reveal animations** — `IntersectionObserver` in base layout adds `.in-view` on scroll; `.reveal` class uses CSS `transition` + `--reveal-delay` custom property for per-item stagger.\n- **Theme default** — first-time visitors get dark mode; returning visitors keep their saved preference.

---
_Generated by [Claude Code](https://claude.ai/code/session_016pZb6cvRAyMtMniZ6CPBYT)_