### PR TITLE
fix: view transitions — blink fix, directional slides, frozen header

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -86,6 +86,7 @@
 		</script>
 		<script>
 			(function () {
+				var vh = window.innerHeight;
 				var obs = new IntersectionObserver(function (entries) {
 					entries.forEach(function (e) {
 						if (e.isIntersecting) {
@@ -94,7 +95,18 @@
 						}
 					});
 				}, { threshold: 0.08 });
-				document.querySelectorAll('.reveal').forEach(function (el) { obs.observe(el); });
+
+				document.querySelectorAll('.reveal').forEach(function (el) {
+					var rect = el.getBoundingClientRect();
+					if (rect.top < vh) {
+						// Already in viewport: mark visible instantly, no transition
+						el.style.transition = 'none';
+						el.classList.add('in-view');
+					} else {
+						// Below fold: animate in on scroll
+						obs.observe(el);
+					}
+				});
 			})();
 		</script>
 		<script type="module" src="{% getBundleFileUrl "js" %}"></script>

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -67,7 +67,9 @@
 		</footer>
 
 		<!-- {{ page.url }} built on {% currentBuildDate %} -->
+
 		<script>
+			/* Theme toggle */
 			(function () {
 				var btn = document.getElementById('theme-toggle');
 				if (!btn) return;
@@ -80,11 +82,61 @@
 					var current = document.documentElement.getAttribute('data-theme') || 'dark';
 					apply(current === 'dark' ? 'light' : 'dark');
 				});
-				var initial = document.documentElement.getAttribute('data-theme') || 'dark';
-				btn.setAttribute('aria-pressed', initial === 'dark');
+				apply(document.documentElement.getAttribute('data-theme') || 'dark');
 			})();
 		</script>
+
 		<script>
+			/* View Transitions: directional types + reveal blink fix */
+			(function () {
+				/* Map URLs to a nav order so we know forward vs backward */
+				function navOrder(url) {
+					if (!url) return 0;
+					if (url.indexOf('/about/') !== -1) return 3;
+					if (url.indexOf('/insights/') !== -1 ||
+						url.indexOf('/blog/')    !== -1 ||
+						url.indexOf('/tags/')    !== -1) return 2;
+					return 1;
+				}
+
+				/* pageswap: fires on the OLD page before snapshot capture.
+				   Set the transition type so CSS can read it on both sides. */
+				window.addEventListener('pageswap', function (e) {
+					if (!e.viewTransition || !e.activation) return;
+					var from = navOrder(e.activation.from  && e.activation.from.url);
+					var to   = navOrder(e.activation.entry && e.activation.entry.url);
+					if (to > from) e.viewTransition.types.add('forward');
+					else if (to < from) e.viewTransition.types.add('backward');
+				});
+
+				/* pagereveal: fires on the NEW page before first paint.
+				   Mark in-viewport .reveal elements visible immediately
+				   so they don’t blink when the transition layer lifts. */
+				window.addEventListener('pagereveal', function (e) {
+					var vh = window.innerHeight;
+					document.querySelectorAll('.reveal:not(.in-view)').forEach(function (el) {
+						if (el.getBoundingClientRect().top < vh) {
+							el.style.transition = 'none';
+							el.classList.add('in-view');
+							requestAnimationFrame(function () { el.style.transition = ''; });
+						}
+					});
+
+					/* Set direction type on incoming page too */
+					if (!e.viewTransition) return;
+					try {
+						var act = navigation.activation;
+						var from = navOrder(act && act.from && act.from.url);
+						var to   = navOrder(location.href);
+						if (to > from) e.viewTransition.types.add('forward');
+						else if (to < from) e.viewTransition.types.add('backward');
+					} catch (_) {}
+				});
+			})();
+		</script>
+
+		<script>
+			/* Scroll reveal: IntersectionObserver for below-fold elements */
 			(function () {
 				var vh = window.innerHeight;
 				var obs = new IntersectionObserver(function (entries) {
@@ -96,19 +148,17 @@
 					});
 				}, { threshold: 0.08 });
 
-				document.querySelectorAll('.reveal').forEach(function (el) {
-					var rect = el.getBoundingClientRect();
-					if (rect.top < vh) {
-						// Already in viewport: mark visible instantly, no transition
+				document.querySelectorAll('.reveal:not(.in-view)').forEach(function (el) {
+					if (el.getBoundingClientRect().top < vh) {
 						el.style.transition = 'none';
 						el.classList.add('in-view');
 					} else {
-						// Below fold: animate in on scroll
 						obs.observe(el);
 					}
 				});
 			})();
 		</script>
+
 		<script type="module" src="{% getBundleFileUrl "js" %}"></script>
 	</body>
 </html>

--- a/css/index.css
+++ b/css/index.css
@@ -54,20 +54,37 @@
 /* ── View Transitions ─────────────────────────────────────── */
 @view-transition { navigation: auto; }
 
-/* Freeze the header - it looks the same on every page */
+/* Header is identical on every page — freeze it */
 header { view-transition-name: site-nav; }
 ::view-transition-old(site-nav),
-::view-transition-new(site-nav) {
-	animation: none;
-	mix-blend-mode: normal;
+::view-transition-new(site-nav) { animation: none; mix-blend-mode: normal; }
+
+/* Default (same-level navigation): subtle slide up */
+::view-transition-old(root) { animation: 180ms ease-in  vt-up-out; }
+::view-transition-new(root) { animation: 300ms ease-out vt-up-in;  }
+
+/* Forward navigation (e.g. Home → Archive → About): slide left */
+html:active-view-transition-type(forward) ::view-transition-old(root) {
+	animation: 200ms ease-in vt-left-out;
+}
+html:active-view-transition-type(forward) ::view-transition-new(root) {
+	animation: 300ms ease-out vt-left-in;
 }
 
-/* Slide the main content */
-::view-transition-old(root) { animation: 180ms ease-in  vt-out; }
-::view-transition-new(root) { animation: 320ms ease-out vt-in;  }
+/* Backward navigation (e.g. About → Archive → Home): slide right */
+html:active-view-transition-type(backward) ::view-transition-old(root) {
+	animation: 200ms ease-in vt-right-out;
+}
+html:active-view-transition-type(backward) ::view-transition-new(root) {
+	animation: 300ms ease-out vt-right-in;
+}
 
-@keyframes vt-out { to   { opacity: 0; transform: translateY(-10px); } }
-@keyframes vt-in  { from { opacity: 0; transform: translateY(14px);  } }
+@keyframes vt-up-out    { to   { opacity: 0; transform: translateY(-10px); } }
+@keyframes vt-up-in     { from { opacity: 0; transform: translateY(14px);  } }
+@keyframes vt-left-out  { to   { opacity: 0; transform: translateX(-24px); } }
+@keyframes vt-left-in   { from { opacity: 0; transform: translateX(24px);  } }
+@keyframes vt-right-out { to   { opacity: 0; transform: translateX(24px);  } }
+@keyframes vt-right-in  { from { opacity: 0; transform: translateX(-24px); } }
 
 /* ── Reset ────────────────────────────────────────────────── */
 * { box-sizing: border-box; }

--- a/css/index.css
+++ b/css/index.css
@@ -54,8 +54,15 @@
 /* ── View Transitions ─────────────────────────────────────── */
 @view-transition { navigation: auto; }
 
+/* Freeze the header - it looks the same on every page */
 header { view-transition-name: site-nav; }
+::view-transition-old(site-nav),
+::view-transition-new(site-nav) {
+	animation: none;
+	mix-blend-mode: normal;
+}
 
+/* Slide the main content */
 ::view-transition-old(root) { animation: 180ms ease-in  vt-out; }
 ::view-transition-new(root) { animation: 320ms ease-out vt-in;  }
 


### PR DESCRIPTION
## What & Why\n\nThree layered fixes for the blinking issue reported between page navigations.\n\n### 1. `pagereveal` blink fix\n`pagereveal` fires on the **new page before the first paint** — before the view transition layer lifts and exposes the real DOM. Any `.reveal` element already in the viewport gets `in-view` applied instantly (with `transition: none`) so there's nothing invisible when the transition completes.\n\n### 2. `pageswap` + directional transition types\n`pageswap` fires on the **old page before snapshot capture**. Both hooks use a `navOrder()` function (Home=1, Archive=2, About=3) to classify the navigation:\n- **Forward** (Home → About): content slides left out, new page enters from right\n- **Backward** (About → Home): content slides right out, new page enters from left  \n- **Same level**: default slide-up\n\nCSS reads the type via `:active-view-transition-type(forward|backward)` — no JS touching the DOM during animation.\n\n### 3. Header frozen correctly\n`view-transition-name: site-nav` with `animation: none` on both `::view-transition-old/new(site-nav)` — the header is captured as its own layer and never animates, eliminating the header flicker caused by `backdrop-filter` rendering differences between snapshots.

---
_Generated by [Claude Code](https://claude.ai/code/session_016pZb6cvRAyMtMniZ6CPBYT)_